### PR TITLE
Fix st2sensorcontainer Startup

### DIFF
--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1124,10 +1124,10 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if $one_sensor_per_pod }}
         command:
           - /opt/stackstorm/st2/bin/st2sensorcontainer
         {{- include "st2-config-file-parameters" . | nindent 10 }}
+        {{- if $one_sensor_per_pod }}
           - --single-sensor-mode
           - --sensor-ref={{ $sensor.ref }}
         {{- end }}


### PR DESCRIPTION
We need to include the --config file stuff regardless of whether or not $one_sensor_per_pod is set.
